### PR TITLE
Added a batch script so the command is executable on Windows

### DIFF
--- a/bin/youtube-upload.bat
+++ b/bin/youtube-upload.bat
@@ -1,0 +1,1 @@
+python %~dp0\youtube-upload %*


### PR DESCRIPTION
So I noticed that on Windows you can't really use the command line function of it that well since Windows will not execute files without a extension. However, it will execute files where you do not specify the extension. Thus, by simple adding a batch script which open the binary file in Python and passes all the arguments into it, one can effectively make calling the utility as easy on Windows as it is on Linux.

In other words, adding youtube-upload to the path now actually does something on Windows so global commands like the ones specified in the readme will actually work.

This is the same workaround that Spyder uses on Windows btw.