### PR TITLE
Fixed Unicode and other issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup_kwargs = {
     "description": "Upload videos to Youtube",
     "author": "Arnau Sanchez",
     "author_email": "tokland@gmail.com",
-    "url": "http://code.google.com/p/youtube-upload/",
+    "url": "https://github.com/tokland/youtube-upload",
     "packages": ["youtube_upload/", "youtube_upload/auth"],
     "data_files": [("share/youtube_upload", ['client_secrets.json'])],
     "scripts": ["bin/youtube-upload"],

--- a/youtube_upload/lib.py
+++ b/youtube_upload/lib.py
@@ -37,7 +37,8 @@ def debug(obj, fd=sys.stderr):
     #Python 3 handling workaround
     if sys.version_info >= (3, 0) and isinstance(string, bytes):
         fd.buffer.write(string + "\n") #We write the encoding directly
-    fd.write(string + "\n")
+    else:
+        fd.write(string + "\n")
 
 def catch_exceptions(exit_codes, fun, *args, **kwargs):
     """


### PR DESCRIPTION
I fixed the issue with 'b appearing before all debug statements in Python 3. A fix to the unicode code apparently broke my Python 3 workaround so I cleaned up and made it more robust. I also added the default Python3 gitignore to the project, and updated the project URL. Finally, I modified my workaround for Python 3 on Windows to always favor the directory being run instead of the system one.