### PR TITLE
Adding command-line script entrypoints to setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup_kwargs = {
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
     ],
+    "entry_points": {
+        'console_scripts': [
+            'youtube-upload = youtube_upload.cmdline:cmdline_main'
+        ],
+    }
 }
 
 setup(**setup_kwargs)

--- a/youtube_upload/cmdline.py
+++ b/youtube_upload/cmdline.py
@@ -1,0 +1,5 @@
+from youtube_upload import main
+
+
+def cmdline_main():
+    main()


### PR DESCRIPTION
Adds a setuptools entrypoint.  This will cause the setup process to automatically create a script in your binary directory (`/usr/local/bin/` if installing globally, or your virtualenv's `bin/` directory if you're installing within a virtualenv) usable for executing your program. This makes it such that installing users do not need to be aware of where the repository (or package, if you were to now register/upload this package to PyPI) is installed given that they will be able to run this script simply by typing `youtube-upload`.

Cheers, and let me know if you have any questions!