### PR TITLE
Add sys.setdefaultencoding('utf8') to main

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -197,6 +197,8 @@ def main(arguments):
     Upload videos to Youtube."""
     parser = optparse.OptionParser(usage)
 
+    sys.setdefaultencoding('utf8')
+    
     # Video metadata
     parser.add_option('-t', '--title', dest='title', type="string",
         help='Video title')


### PR DESCRIPTION
Added sys.setdefaultencoding('utf8') to main, Solves “UnicodeDecodeError: 'ascii' codec can't decode byte”

As per http://stackoverflow.com/questions/21129020/how-to-fix-unicodedecodeerror-ascii-codec-cant-decode-byte

https://github.com/tokland/youtube-upload/issues/107

Video uploaded successfully after the change. 