### PR TITLE
bring back progressbar ETA

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -65,9 +65,12 @@ def get_progress_info():
 
     if progressbar:
         bar = progressbar.ProgressBar(widgets=[
-            progressbar.Percentage(), ' ',
-            progressbar.Bar(), ' ',
-            progressbar.FileTransferSpeed(),
+            progressbar.Percentage(),
+            ' ', progressbar.Bar(),
+            ' ', progressbar.FileTransferSpeed(),
+            ' ', progressbar.DataSize(), '/', progressbar.DataSize('max_value'),
+            ' ', progressbar.Timer(),
+            ' ', progressbar.AdaptiveETA(),
         ])
         def _callback(total_size, completed):
             if not hasattr(bar, "next_update"):


### PR DESCRIPTION
as upstream `progressbar2` have handled Overflow exception,
now it's safe to use ETA, 

plus more info for upload progress, which give me info on really slow 4k video upload,

as `progressbar2` do provide a default widgets set as `progressbar.bar.DataTransferBar`,
this is just more or less a personal preference to show information

` 12% |##              |   2.1 MiB/s   1.8 GiB/ 13.9 GiB Elapsed Time: 0:14:35 ETA: 1:56:05`