### PR TITLE
Use open function from io module.

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -20,6 +20,7 @@ import sys
 import optparse
 import collections
 import webbrowser
+from io import open
 
 import googleapiclient.errors
 import oauth2client


### PR DESCRIPTION
Open function prior to Python 3 does not have encoding parameter (fails on Python 2.x), but io.open is more portable.