### PR TITLE
Fix UnicodeEncodeError for server response errors

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -255,7 +255,7 @@ def main(arguments):
         run_main(parser, options, args)
     except googleapiclient.errors.HttpError as error:
         response = bytes.decode(error.content, encoding=lib.get_encoding()).strip()
-        raise RequestError("Server response: {0}".format(response))
+        raise RequestError(u"Server response: {0}".format(response))
 
 def run():
     sys.exit(lib.catch_exceptions(EXIT_CODES, main, sys.argv[1:]))


### PR DESCRIPTION
I received the following error at the end of uploading a video:

UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in
position 1441: ordinal not in range(128)

This change should fix #150 by making the format string also be unicode.