### PR TITLE
Retry HTTP 5xx errors and avoid raising UnicodeEncodeError

### DIFF
--- a/youtube_upload/upload_video.py
+++ b/youtube_upload/upload_video.py
@@ -16,6 +16,7 @@ RETRIABLE_EXCEPTIONS = [
     httplib.IncompleteRead, httplib.ImproperConnectionState,
     httplib.CannotSendRequest, httplib.CannotSendHeader,
     httplib.ResponseNotReady, httplib.BadStatusLine,
+    googleapiclient.errors.HttpError,
 ]
 
 def _upload_to_request(request, progress_callback):


### PR DESCRIPTION
My intention was to fix `UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 1441: ordinal not in range(128)` error.

For me this error happens when Google servers respond with HTTP 502 or 503 error during peak hours. After this patch video uploads correctly using a few retries.

```
Using client secrets: ...
Using credentials file: ...
Start upload: ...
 78% |#######################################################################################################################################################                                         |   1.2 MiB/s
[Retryable error 1/10] HttpError (<HttpError 502 when requesting https://www.googleapis.com/upload/youtube/v3/videos?uploadType=resumable&alt=json&part=snippet%2Cstatus%2CrecordingDetails returned "Bad Gateway">). Wait 0.1 seconds
100% |################################################################################################################################################################################################|   1.1 MiB/s
Video URL: https://www.youtube.com/watch?v=YTVideoID
YTVideoID
```

Before this patch:

```
Using client secrets: ...
Using credentials file: ...
Start upload: ...
100% |################################################################################################################################################################|   2.9 MiB/s
Traceback (most recent call last):
  File ".../bin/youtube-upload", line 10, in <module>
    main.run()
  File ".../bin/../youtube_upload/main.py", line 261, in run
    sys.exit(lib.catch_exceptions(EXIT_CODES, main, sys.argv[1:]))
  File ".../bin/../youtube_upload/lib.py", line 42, in catch_exceptions
    fun(*args, **kwargs)
  File ".../bin/../youtube_upload/main.py", line 258, in main
    raise RequestError("Server response: {0}".format(response))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 1441: ordinal not in range(128)
```

Maybe this is related to #150 #162 