### PR TITLE
Added missing library dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup_kwargs = {
     },
     "install_requires":[
         'google-api-python-client',
+        'oauth2client',
         'progressbar2'
     ]
 }


### PR DESCRIPTION
Installing and running `youtube-upload` on a relatively clean machine results in the following message:

```
$ youtube-upload 
Traceback (most recent call last):
  File "/home/zpalmer/.local/bin/youtube-upload", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/zpalmer/software/checkouts/youtube-upload/bin/youtube-upload", line 9, in <module>
    from youtube_upload import main    
  File "/home/zpalmer/software/checkouts/youtube-upload/bin/../youtube_upload/main.py", line 26, in <module>
    import oauth2client
ImportError: No module named oauth2client
```

This PR modifies `setup.py` to require the pip package `oauth2client` to resolve this issue.