### PR TITLE
Fix faulty import

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -35,7 +35,7 @@ from . import playlists
 
 # http://code.google.com/p/python-progressbar (>= 2.3)
 try:
-    import progressbar2
+    import progressbar
 except ImportError:
     progressbar = None
 


### PR DESCRIPTION
Based on https://progressbar-2.readthedocs.io/en/latest/ and @BookWorm0 comment on #284 
This should fix the issue with missing progressbar.

Tested on Ubuntu 16.04 with Python 3.5