### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The package used to include a default ```client_secrets.json``` file. It does no
 * Go to the Google [console](https://console.developers.google.com/).
 * _Create project_.
 * Side menu: _APIs & auth_ -> _APIs_
-* Top menu: _Enabled API(s)_: Enable all Youtube APIs.
+* Top menu: _Enabled API(s)_: Enable Youtube OAuth API.
 * Side menu: _APIs & auth_ -> _Credentials_.
-* _Create a Client ID_: Add credentials -> OAuth 2.0 Client ID -> Other -> Name: youtube-upload -> Create -> OK
+* _Create a Client ID_: Add credentials -> OAuth 2.0 Client ID -> Desktop Application -> Name: youtube-upload -> Create -> OK
 * _Download JSON_: Under the section "OAuth 2.0 client IDs". Save the file to your local system. 
 * Use this JSON as your credentials file: `--client-secrets=CLIENT_SECRETS` or copy it to `~/client_secrets.json`.
 


### PR DESCRIPTION
The steps have changed slightly on the Google GUI. I was able to upload a video using the above alternate selection. The other youtube APIs were reporting and analytics, which I didn't enable and still was able to upload a video with, and there is no longer an "Other" option for application type, but "Desktop Application" returned me a success code which worked when copied to the `youtube-upload` prompt.