### PR TITLE
Add setuptools import to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 """Upload videos to Youtube."""
 from distutils.core import setup
+import setuptools
 
 setup_kwargs = {
     "name": "youtube-upload",


### PR DESCRIPTION
This fixes a distutils error for unknown distribution options:
'entry_points' and 'install_requires'. See
https://stackoverflow.com/a/50722265/1905235