### PR TITLE
Fix import for progressbar2

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -35,7 +35,7 @@ from . import playlists
 
 # http://code.google.com/p/python-progressbar (>= 2.3)
 try:
-    import progressbar2
+    import progressbar
 except ImportError:
     progressbar = None
 


### PR DESCRIPTION
The test for progressbar2 is incorrect in the code.
The said package, [progressbar2](https://pypi.org/project/progressbar2/) imports as `progressbar` and not `progressbar2`.
This change corrects the test for availability of the progressbar2 package by importing it correctly.