### PR TITLE
Issue with progressbar

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -35,7 +35,7 @@ from . import playlists
 
 # http://code.google.com/p/python-progressbar (>= 2.3)
 try:
-    import progressbar2
+    import progressbar
 except ImportError:
     progressbar = None
 


### PR DESCRIPTION
Hello Developers, In the main.py, the progressbar2 is imported as `import progressbar2`.  This gives an error and since the error is caught the progress bar is not shown.  Even though progressbar2 is installed as pip install progressbar2, when you import it is imported as `import progressbar`.  I have made this small change in my fork.  I tested it on my Linux Debain system and it is working.  Please look into it and help.  

Thanks a lot for your great work.  

Best regards,
-Jithesh 