### PR TITLE
Added new mandatory field to payload "selfDeclaredMadeForKids"

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -148,6 +148,7 @@ def upload_youtube_video(youtube, options, video_path, total_videos, index):
             "privacyStatus": ("private" if options.publish_at else options.privacy),
             "publishAt": options.publish_at,
             "license": options.license,
+            "selfDeclaredMadeForKids": False,
 
         },
         "recordingDetails": {


### PR DESCRIPTION
YouTube will not publish unless that field is explicitly set.

Defaults to False.... enough to get it to work

Future work: perhaps this should be added as a parameter